### PR TITLE
Add project description and links for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ version = "3.2.0"
 description = "A headless login / logout script for 10.0.0.55"
 authors = ["spencerwooo <spencer.woo@outlook.com>"]
 license = "MIT"
+readme = "README.md"
+homepage = "https://github.com/BITNP/10_0_0_55_login"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4"


### PR DESCRIPTION
Currently [the PyPI page](https://pypi.org/project/bitsrun/) is nearly empty.

This PR fill [readme](https://python-poetry.org/docs/pyproject#readme) and [homepage](https://python-poetry.org/docs/pyproject#homepage) of `pyproject.toml`. Next time you publish, they will become Project links → Homepage and Project description respectively.