### PR TITLE
Use `click.echo()` for colored outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,17 @@ pipx install bitsrun
 ```text
 Usage: bitsrun login/logout [OPTIONS]
 
-  Log in/out the BIT network.
+  Log into or out of the BIT network.
 
 Options:
   -u, --username TEXT  Username.
   -p, --password TEXT  Password.
-  -v, --verbose        Verbose output.
-  -s, --silent         Silent output.
-  -nc, --no-color      No color output.
+  -v, --verbose        Verbosely echo API response.
+  -s, --silent         Silent, no output to stdout.
   --help               Show this message and exit.
 ```
+
+> **Note**: this is the output of `bitsrun login/logout --help`.
 
 ### Configuration file
 

--- a/bitsrun/cli.py
+++ b/bitsrun/cli.py
@@ -12,9 +12,8 @@ from bitsrun.user import User
 _options = [
     click.option("-u", "--username", help="Username.", required=False),
     click.option("-p", "--password", help="Password.", required=False),
-    click.option("-v", "--verbose", is_flag=True, help="Verbose output."),
-    click.option("-s", "--silent", is_flag=True, help="Silent output."),
-    click.option("-nc", "--no-color", is_flag=True, help="No color output."),
+    click.option("-v", "--verbose", is_flag=True, help="Verbosely echo API response."),
+    click.option("-s", "--silent", is_flag=True, help="Silent, no output to stdout."),
 ]
 
 
@@ -29,6 +28,7 @@ def add_options(options):
 
 # Declaration of the main command group starts here
 @click.group()
+@click.version_option()
 def cli():
     pass
 
@@ -41,16 +41,16 @@ def config_paths():
 
 @cli.command()
 @add_options(_options)
-def login(kwargs):
+def login(username, password, verbose, silent, no_color):
     """Log into the BIT network."""
-    do_action("login", **kwargs)
+    do_action("login", username, password, verbose, silent, no_color)
 
 
 @cli.command()
 @add_options(_options)
-def logout(kwargs):
+def logout(username, password, verbose, silent, no_color):
     """Log out of the BIT network."""
-    do_action("logout", **kwargs)
+    do_action("logout", username, password, verbose, silent, no_color)
 
 
 def do_action(action, username, password, verbose, silent, no_color):
@@ -71,27 +71,21 @@ def do_action(action, username, password, verbose, silent, no_color):
 
             # Output login result by default if not silent
             if not silent:
-                print(f"{res.get('username')} ({res.get('online_ip')}) logged in")
+                click.echo(f"{res.get('username')} ({res.get('online_ip')}) logged in")
 
         else:
             res = user.do_action(Action.LOGOUT)
 
             # Output logout result by default if not silent
             if not silent:
-                print(res.get("online_ip"), "logged out")
+                click.echo(res.get("online_ip"), "logged out")
 
         # Output direct result of response if verbose
         if verbose:
-            if no_color:
-                print("Info:", res)
-            else:
-                print("\33[34m[Info]\033[0m", res)
+            click.secho(f"Info: {res}", fg="blue")
 
     except Exception as e:
-        if no_color:
-            print("Error:", e)
-        else:
-            print("\033[91m[Error]", e, "\033[0m")
+        click.secho(f"[Error] {e}", fg="red")
 
         # Throw with error code 1 for scripts to pick up error state
         sys.exit(1)

--- a/bitsrun/cli.py
+++ b/bitsrun/cli.py
@@ -17,6 +17,7 @@ _options = [
 ]
 
 
+# Decorator to add options to a click command (used w/ the hack above)
 def add_options(options):
     def _add_options(func):
         for option in reversed(options):
@@ -41,19 +42,19 @@ def config_paths():
 
 @cli.command()
 @add_options(_options)
-def login(username, password, verbose, silent, no_color):
+def login(username, password, verbose, silent):
     """Log into the BIT network."""
-    do_action("login", username, password, verbose, silent, no_color)
+    do_action("login", username, password, verbose, silent)
 
 
 @cli.command()
 @add_options(_options)
-def logout(username, password, verbose, silent, no_color):
+def logout(username, password, verbose, silent):
     """Log out of the BIT network."""
-    do_action("logout", username, password, verbose, silent, no_color)
+    do_action("logout", username, password, verbose, silent)
 
 
-def do_action(action, username, password, verbose, silent, no_color):
+def do_action(action, username, password, verbose, silent):
     """Log in/out the BIT network."""
     if username and not password:
         password = getpass(prompt="Please enter your password: ")
@@ -85,7 +86,7 @@ def do_action(action, username, password, verbose, silent, no_color):
             click.secho(f"Info: {res}", fg="blue")
 
     except Exception as e:
-        click.secho(f"[Error] {e}", fg="red")
+        click.secho(f"Error: {e}", fg="red")
 
         # Throw with error code 1 for scripts to pick up error state
         sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitsrun"
-version = "3.2.3"
+version = "3.2.4"
 description = "A headless login / logout script for 10.0.0.55"
 authors = ["spencerwooo <spencer.woo@outlook.com>"]
 license = "MIT"

--- a/scripts/login-10.0.0.55.sh
+++ b/scripts/login-10.0.0.55.sh
@@ -14,4 +14,4 @@
 # @raycast.author Spencer Woo
 # @raycast.authorURL https://spencerwoo.com
 
-bitsrun login --no-color
+bitsrun login

--- a/scripts/logout-10.0.0.55.sh
+++ b/scripts/logout-10.0.0.55.sh
@@ -14,4 +14,4 @@
 # @raycast.author Spencer Woo
 # @raycast.authorURL https://spencerwoo.com
 
-bitsrun logout --no-color
+bitsrun logout


### PR DESCRIPTION
- Adds `--version` with `@click.version_option()`
- Removes option `--no-color`
- `click.secho()` should be able to automatically detect terminal environments

⚠️ ~~Not tested with Raycast yet, as the option `--no-color` is primarily used for that script.~~ Tested when called in Raycast, colors are automatically suppressed.

⏳ ~~WIP: testing on hold until I get back on campus.~~