### PR TITLE
fix: config root missing `$HOME/.config/bitsrun/` on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ _A headless login / logout script for 10.0.0.55 at BIT._
 
 You need at least **Python 3.8**. We recommend installing with `pipx`.
 
-```bash
+```shell
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
 ```
 
 After which, install `bitsrun` with `pipx`.
 
-```bash
+```shell
 pipx install bitsrun
 ```
 
@@ -55,7 +55,7 @@ This file should be put under the following directory:
 
 Now you can simply call:
 
-```bash
+```shell
 bitsrun login
 bitsrun logout
 ```
@@ -78,7 +78,7 @@ Import the two Raycast scripts from [`./scripts`](./scripts/) and setup your con
 
 Install and run:
 
-```bash
+```shell
 # Create virtual env and install deps
 poetry install
 
@@ -91,7 +91,7 @@ pre-commit install
 
 Build:
 
-```bash
+```shell
 # Bump version
 poetry version x.x.x
 
@@ -101,7 +101,7 @@ poetry build
 
 Publish:
 
-```bash
+```shell
 poetry publish
 ```
 

--- a/bitsrun/config.py
+++ b/bitsrun/config.py
@@ -17,12 +17,21 @@ def get_config_paths() -> map:
     - `C:\ProgramData\bitsrun\bit-user.json`
     - `~\AppData\Roaming\bitsrun\bit-user.json`
 
-    On macOS and Linux:
+    On Linux:
 
     - `/etc/bitsrun/bit-user.json`
+    - `/etc/xdg/bitsrun/bit-user.json`
     - `$XDG_CONFIG_HOME/bitsrun/bit-user.json`
     - `~/.config/bitsrun/bit-user.json`
     - `~/.config/bit-user.json`
+
+    On macOS:
+
+    - `/etc/bit-user.json`
+    - `/Library/Preferences/bitsrun/bit-user.json`
+    - `$HOME/Library/Preferences/bitsrun/bit-user.json`
+    - `$HOME/.config/bit-user.json`
+    - `$HOME/.config/bitsrun/bit-user.json`
 
     Returns:
         A map of possible paths of the configuration file based on the current platform.
@@ -43,6 +52,7 @@ def get_config_paths() -> map:
                 paths.append(Path(xdg_config_home))
             else:
                 paths.append(Path.home() / ".config")
+            paths.append(paths[-1] / _APP_NAME)
         else:
             paths.append(user_config_path())
 

--- a/bitsrun/config.py
+++ b/bitsrun/config.py
@@ -21,7 +21,6 @@ def get_config_paths() -> map:
 
     - `/etc/bitsrun/bit-user.json`
     - `/etc/xdg/bitsrun/bit-user.json`
-    - `$XDG_CONFIG_HOME/bitsrun/bit-user.json`
     - `~/.config/bitsrun/bit-user.json`
     - `~/.config/bit-user.json`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitsrun"
-version = "3.3.0"
+version = "3.3.1"
 description = "A headless login / logout script for 10.0.0.55"
 authors = ["spencerwooo <spencer.woo@outlook.com>"]
 license = "WTFPL"


### PR DESCRIPTION
Close #10 

https://github.com/BITNP/bitsrun/blob/928fd4b1a0ff6189bcd8a3e85174e664d63cd02b/bitsrun/config.py#L15-L34

cc @YDX-2147483647, please check on Windows and Linux ;)
