### PR TITLE
feat: get status and a unified endpoint for `ac_id` and `ip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ pipx install bitsrun
 
 Check login status of your device.
 
+![bitsrun status](https://user-images.githubusercontent.com/32114380/216757172-368d74bc-ad74-4122-9b1f-9568ce0341d3.png)
+
 ```text
 Usage: bitsrun status [OPTIONS]
 
@@ -43,6 +45,8 @@ Options:
 > **Note**: this is the output of `bitsrun status --help`.
 
 Login or logout with your username and password.
+
+![bitsrun login](https://user-images.githubusercontent.com/32114380/216757151-b6e8c620-48b6-4411-ac41-f07b79ef9827.png)
 
 ```text
 Usage: bitsrun login/logout [OPTIONS]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ pipx install bitsrun
 
 ### CLI
 
+Check login status of your device.
+
+```text
+Usage: bitsrun status [OPTIONS]
+
+  Check current network login status.
+
+Options:
+  --help  Show this message and exit.
+```
+
+> **Note**: this is the output of `bitsrun status --help`.
+
+Login or logout with your username and password.
+
 ```text
 Usage: bitsrun login/logout [OPTIONS]
 

--- a/bitsrun/models.py
+++ b/bitsrun/models.py
@@ -1,0 +1,32 @@
+from enum import Enum
+from typing import Literal, Optional, TypedDict, Union
+
+
+class Action(Enum):
+    LOGIN = "login"
+    LOGOUT = "logout"
+
+
+class UserResponseType(TypedDict):
+    client_ip: str
+    online_ip: str
+    # Field `error` is also `login_error` when logout action fails
+    error: Union[Literal["login_error"], Literal["ok"]]
+    error_msg: str
+    res: Union[Literal["login_error"], Literal["ok"]]
+    # Field `username` is not present on login fails and all logout scenarios
+    username: Optional[str]
+
+
+class LoginStatusRespType(TypedDict):
+    # Field `error` is `not_online_error` when device is not logged in
+    error: str
+    client_ip: Optional[str]
+    # Field `online_ip` is always present regardless of login status
+    online_ip: str
+    # Below are fields only present when device is logged in
+    sum_bytes: Optional[int]
+    sum_seconds: Optional[int]
+    user_balance: Optional[int]
+    user_name: Optional[str]
+    wallet_balance: Optional[int]

--- a/bitsrun/user.py
+++ b/bitsrun/user.py
@@ -1,46 +1,16 @@
 import hmac
 import json
-from enum import Enum
 from hashlib import sha1
-from typing import Dict, Literal, Optional, TypedDict, Union
+from typing import Dict, Optional, Union
 
 import httpx
 
+from bitsrun.models import Action, LoginStatusRespType, UserResponseType
 from bitsrun.utils import fkbase64, xencode
 
 _API_BASE = "http://10.0.0.55"
 _TYPE_CONST = 1
 _N_CONST = 200
-
-
-class Action(Enum):
-    LOGIN = "login"
-    LOGOUT = "logout"
-
-
-class UserResponseType(TypedDict):
-    client_ip: str
-    online_ip: str
-    # Field `error` is also `login_error` when logout action fails
-    error: Union[Literal["login_error"], Literal["ok"]]
-    error_msg: str
-    res: Union[Literal["login_error"], Literal["ok"]]
-    # Field `username` is not present on login fails and all logout scenarios
-    username: Optional[str]
-
-
-class LoginStatusRespType(TypedDict):
-    # Field `error` is `not_online_error` when device is not logged in
-    error: str
-    client_ip: Optional[str]
-    # Field `online_ip` is always present regardless of login status
-    online_ip: str
-    # Below are fields only present when device is logged in
-    sum_bytes: Optional[int]
-    sum_seconds: Optional[int]
-    user_balance: Optional[int]
-    user_name: Optional[str]
-    wallet_balance: Optional[int]
 
 
 def get_login_status(client: Optional[httpx.Client] = None) -> LoginStatusRespType:

--- a/bitsrun/utils.py
+++ b/bitsrun/utils.py
@@ -1,6 +1,46 @@
 import math
 from base64 import b64encode
 
+from humanize import naturaldelta, naturalsize
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+from bitsrun.models import LoginStatusRespType
+
+
+def print_status_table(login_status: LoginStatusRespType) -> None:
+    """Print the login status table to the console if logged in.
+
+    You should get something like this:
+
+    ┌──────────────┬──────────────┬──────────────┬──────────────┐
+    │ Traffic Used │ Online Time  │ User Balance │ Wallet       │
+    ├──────────────┼──────────────┼──────────────┼──────────────┤
+    │ 879.3 MiB    │ 3 hours      │ 10.00        │ 0.00         │
+    └──────────────┴──────────────┴──────────────┴──────────────┘
+    """
+
+    if not login_status.get("user_name"):
+        return
+
+    table = Table(box=box.SQUARE)
+
+    table.add_column("Traffic Used", style="magenta", width=12)
+    table.add_column("Online Time", style="yellow", width=12)
+    table.add_column("User Balance", style="green", width=12)
+    table.add_column("Wallet", style="blue", width=12)
+
+    table.add_row(
+        naturalsize(login_status.get("sum_bytes", 0), binary=True),  # type: ignore
+        naturaldelta(login_status.get("sum_seconds", 0)),  # type: ignore
+        f"{login_status.get('user_balance', 0):0.2f}",
+        f"{login_status.get('wallet_balance', 0):0.2f}",
+    )
+
+    console = Console()
+    console.print(table)
+
 
 def fkbase64(raw_s: str) -> str:
     """Encode string with a magic base64 mask"""

--- a/bitsrun/utils.py
+++ b/bitsrun/utils.py
@@ -1,53 +1,5 @@
 import math
 from base64 import b64encode
-from html.parser import HTMLParser
-from typing import Tuple
-
-import httpx
-
-
-def parse_homepage(api_base: str) -> Tuple[str, str]:
-    """Parse homepage of 10.0.0.55 and get the acid + ip of current session.
-
-    Raises:
-        Exception: Throw exception if acid not present in the redirected URL.
-        Exception: Throw exception if response text does not contain IP.
-
-    Returns:
-        A tuple of (ip, acid) of the current session.
-    """
-
-    res = httpx.get(api_base, follow_redirects=True)
-
-    # ac_id appears in the url query parameter of the redirected URL
-    ac_id = res.url.params.get("ac_id")
-
-    if not ac_id:
-        raise Exception("failed to get acid")
-
-    # ip appears in the response HTML
-    class IPParser(HTMLParser):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.ip = None
-
-        def handle_starttag(self, tag, attrs):
-            if tag == "input":
-                attr_dict = dict(attrs)
-                if attr_dict.get("name") == "user_ip":
-                    self.ip = attr_dict["value"]
-
-        def feed(self, *args, **kwargs):
-            super().feed(*args, **kwargs)
-            return self.ip
-
-    parser = IPParser()
-    ip = parser.feed(res.text)
-
-    if not ip:
-        raise Exception("failed to get ip")
-
-    return ip, ac_id[0]
 
 
 def fkbase64(raw_s: str) -> str:

--- a/pdm.lock
+++ b/pdm.lock
@@ -95,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.5.0"
+requires_python = ">=3.7"
+summary = "Python humanize utilities"
+
+[[package]]
 name = "identify"
 version = "2.5.17"
 requires_python = ">=3.7"
@@ -105,6 +111,21 @@ name = "idna"
 version = "3.4"
 requires_python = ">=3.5"
 summary = "Internationalized Domain Names in Applications (IDNA)"
+
+[[package]]
+name = "markdown-it-py"
+version = "2.1.0"
+requires_python = ">=3.7"
+summary = "Python port of markdown-it. Markdown parsing, done right!"
+dependencies = [
+    "mdurl~=0.1",
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+requires_python = ">=3.7"
+summary = "Markdown URL utilities"
 
 [[package]]
 name = "mypy"
@@ -163,6 +184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.14.0"
+requires_python = ">=3.6"
+summary = "Pygments is a syntax highlighting package written in Python."
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 requires_python = ">=3.6"
@@ -181,6 +208,17 @@ summary = "Validating URI References per RFC 3986"
 dependencies = [
     "idna",
     "rfc3986==1.5.0",
+]
+
+[[package]]
+name = "rich"
+version = "13.3.1"
+requires_python = ">=3.7.0"
+summary = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+dependencies = [
+    "markdown-it-py<3.0.0,>=2.1.0",
+    "pygments<3.0.0,>=2.14.0",
+    "typing-extensions<5.0,>=4.0.0; python_version < \"3.9\"",
 ]
 
 [[package]]
@@ -226,7 +264,7 @@ dependencies = [
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:cc0626bc3792800e8a7c0cc552ca6fa6f6ab5020d8abf7dc15e09b463a3029d2"
+content_hash = "sha256:1f056ba916522a6be1602e4f53e74501ddde37e364cb613de186ce49b1f06099"
 
 [metadata.files]
 "anyio 3.6.2" = [
@@ -296,6 +334,10 @@ content_hash = "sha256:cc0626bc3792800e8a7c0cc552ca6fa6f6ab5020d8abf7dc15e09b463
     {url = "https://files.pythonhosted.org/packages/ac/a2/0260c0f5d73bdf06e8d3fc1013a82b9f0633dc21750c9e3f3cb1dba7bb8c/httpx-0.23.3-py3-none-any.whl", hash = "sha256:a211fcce9b1254ea24f0cd6af9869b3d29aba40154e947d2a07bb499b3e310d6"},
     {url = "https://files.pythonhosted.org/packages/f5/50/04d5e8ee398a10c767a341a25f59ff8711ae3adf0143c7f8b45fc560d72d/httpx-0.23.3.tar.gz", hash = "sha256:9818458eb565bb54898ccb9b8b251a28785dd4a55afbc23d0eb410754fe7d0f9"},
 ]
+"humanize 4.5.0" = [
+    {url = "https://files.pythonhosted.org/packages/ab/bf/4e526ef224ca00f0a2f14513895c8a728aa94682ebbe756447de41230baa/humanize-4.5.0-py3-none-any.whl", hash = "sha256:127e333677183070b82e90e0faef9440f9a16dab92143e52f4523afb08ca9290"},
+    {url = "https://files.pythonhosted.org/packages/de/ec/c9fa9a0e2b917bd74c18f9752912fd389b7d8e796cfb864e3c485a9bda5d/humanize-4.5.0.tar.gz", hash = "sha256:d6ed00ed4dc59a66df71012e3d69cf655d7d21b02112d435871998969e8aedc8"},
+]
 "identify 2.5.17" = [
     {url = "https://files.pythonhosted.org/packages/6b/c1/dcb61490b9324dd6c4b071835ce89840536a636512100e300e67e27ab447/identify-2.5.17.tar.gz", hash = "sha256:93cc61a861052de9d4c541a7acb7e3dcc9c11b398a2144f6e52ae5285f5f4f06"},
     {url = "https://files.pythonhosted.org/packages/74/6f/752581a147e65f86c00ae0debb21f2217638ff3ca15e7a623f1ff53198a3/identify-2.5.17-py2.py3-none-any.whl", hash = "sha256:7d526dd1283555aafcc91539acc061d8f6f59adb0a7bba462735b0a318bff7ed"},
@@ -303,6 +345,14 @@ content_hash = "sha256:cc0626bc3792800e8a7c0cc552ca6fa6f6ab5020d8abf7dc15e09b463
 "idna 3.4" = [
     {url = "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
     {url = "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+]
+"markdown-it-py 2.1.0" = [
+    {url = "https://files.pythonhosted.org/packages/33/e9/ac8a93e9eda3891ecdfecf5e01c060bbd2c44d4e3e77efc83b9c7ce9db32/markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},
+    {url = "https://files.pythonhosted.org/packages/f9/3f/ecd1b708973b9a3e4574b43cffc1ce8eb98696da34f1a1c44a68c3c0d737/markdown_it_py-2.1.0-py3-none-any.whl", hash = "sha256:93de681e5c021a432c63147656fe21790bc01231e0cd2da73626f1aa3ac0fe27"},
+]
+"mdurl 0.1.2" = [
+    {url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
 "mypy 0.991" = [
     {url = "https://files.pythonhosted.org/packages/0e/5c/fbe112ca73d4c6a9e65336f48099c60800514d8949b4129c093a84a28dc8/mypy-0.991.tar.gz", hash = "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06"},
@@ -360,6 +410,10 @@ content_hash = "sha256:cc0626bc3792800e8a7c0cc552ca6fa6f6ab5020d8abf7dc15e09b463
     {url = "https://files.pythonhosted.org/packages/1a/fc/dec2f3a2850d2e0d9b499db12a574e53a502d8bd89f3928be2b42d112200/pre_commit-3.0.3-py2.py3-none-any.whl", hash = "sha256:83e2e8cc5cbb3691cff9474494816918d865120768aa36c9eda6185126667d21"},
     {url = "https://files.pythonhosted.org/packages/97/e9/26c7a792c8793e844ccfdac1e832136909f9a49dde32550b961edfacb51e/pre_commit-3.0.3.tar.gz", hash = "sha256:4187e74fda38f0f700256fb2f757774385503b04292047d0899fc913207f314b"},
 ]
+"pygments 2.14.0" = [
+    {url = "https://files.pythonhosted.org/packages/0b/42/d9d95cc461f098f204cd20c85642ae40fbff81f74c300341b8d0e0df14e0/Pygments-2.14.0-py3-none-any.whl", hash = "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"},
+    {url = "https://files.pythonhosted.org/packages/da/6a/c427c06913204e24de28de5300d3f0e809933f376e0b7df95194b2bb3f71/Pygments-2.14.0.tar.gz", hash = "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297"},
+]
 "pyyaml 6.0" = [
     {url = "https://files.pythonhosted.org/packages/02/25/6ba9f6bb50a3d4fbe22c1a02554dc670682a07c8701d1716d19ddea2c940/PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {url = "https://files.pythonhosted.org/packages/08/f4/ffa743f860f34a5e8c60abaaa686f82c9ac7a2b50e5a1c3b1eb564d59159/PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
@@ -405,6 +459,10 @@ content_hash = "sha256:cc0626bc3792800e8a7c0cc552ca6fa6f6ab5020d8abf7dc15e09b463
 "rfc3986 1.5.0" = [
     {url = "https://files.pythonhosted.org/packages/79/30/5b1b6c28c105629cc12b33bdcbb0b11b5bb1880c6cfbd955f9e792921aa8/rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
     {url = "https://files.pythonhosted.org/packages/c4/e5/63ca2c4edf4e00657584608bee1001302bbf8c5f569340b78304f2f446cb/rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
+]
+"rich 13.3.1" = [
+    {url = "https://files.pythonhosted.org/packages/68/31/b8934896818c885001aeb7df388ba0523ea3ec88ad31805983d9b0480a50/rich-13.3.1.tar.gz", hash = "sha256:125d96d20c92b946b983d0d392b84ff945461e5a06d3867e9f9e575f8697b67f"},
+    {url = "https://files.pythonhosted.org/packages/a8/c6/14b77fe7a5fab66ffbeffd6706f598d00a52702846bce0e2339bcf9dd20c/rich-13.3.1-py3-none-any.whl", hash = "sha256:8aa57747f3fc3e977684f0176a88e789be314a99f99b43b75d1e9cb5dc6db9e9"},
 ]
 "ruff 0.0.240" = [
     {url = "https://files.pythonhosted.org/packages/0b/56/8c47f6331621afa66b20063024a3de1911e72fbab2c48772b143cc677d48/ruff-0.0.240-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f58f1122001150d70909885ccf43d869237be814d4cfc74bb60b3883635e440a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ dependencies = [
     "click<9.0.0,>=8.1.3",
     "platformdirs<3.0.0,>=2.6.2",
     "httpx>=0.23.3",
+    "rich>=13.3.1",
+    "humanize>=4.5.0",
 ]
 requires-python = ">=3.8,<4.0"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bitsrun"
-version = "3.3.1"
+version = "3.4.0"
 description = "A headless login / logout script for 10.0.0.55"
 authors = [{ name = "spencerwooo", email = "spencer.woo@outlook.com" }]
 dependencies = [


### PR DESCRIPTION
- Get device login status with command `bitsrun status`
- Refactor to use a unified endpoint for acquiring `ac_id` and `ip`

Close #22 