### PR TITLE
feat: output status in JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Usage: bitsrun status [OPTIONS]
   Check current network login status.
 
 Options:
+  --json / --no-json  Output in JSON format.
   --help  Show this message and exit.
 ```
 

--- a/bitsrun/cli.py
+++ b/bitsrun/cli.py
@@ -1,5 +1,6 @@
 import sys
 from getpass import getpass
+from json import dumps
 
 import click
 from rich import print_json
@@ -41,16 +42,20 @@ def config_paths():
 
 
 @cli.command()
-def status():
+@click.option("--json/--no-json", default=False, help="Output in JSON format.")
+def status(json: bool):
     """Check current network login status."""
     login_status = get_login_status()
 
     if login_status.get("user_name"):
-        click.echo(
-            click.style("bitsrun: ", fg="green")
-            + f"{login_status['user_name']} ({login_status['online_ip']}) is online"
-        )
-        print_status_table(login_status)
+        if json:
+            print(dumps(login_status))
+        else:
+            click.echo(
+                click.style("bitsrun: ", fg="green")
+                + f"{login_status['user_name']} ({login_status['online_ip']}) is online"
+            )
+            print_status_table(login_status)
 
     else:
         click.echo(

--- a/bitsrun/cli.py
+++ b/bitsrun/cli.py
@@ -47,16 +47,18 @@ def status(json: bool):
     """Check current network login status."""
     login_status = get_login_status()
 
-    if login_status.get("user_name"):
-        if json:
-            print(dumps(login_status))
-        else:
-            click.echo(
-                click.style("bitsrun: ", fg="green")
-                + f"{login_status['user_name']} ({login_status['online_ip']}) is online"
-            )
-            print_status_table(login_status)
+    # Output in JSON format if `--json` is passed, then exit
+    if json:
+        print(dumps(login_status))
+        return
 
+    # Output in human-readable format
+    if login_status.get("user_name"):
+        click.echo(
+            click.style("bitsrun: ", fg="green")
+            + f"{login_status['user_name']} ({login_status['online_ip']}) is online"
+        )
+        print_status_table(login_status)
     else:
         click.echo(
             click.style("bitsrun: ", fg="cyan")


### PR DESCRIPTION
I want to use `bitsrun status` in a shell script, and a JSON output would simplify things.

---

> JSON allows for more structure than plain text, so it makes it much easier to output and handle complex data structures. [jq](https://stedolan.github.io/jq/) is a common tool for working with JSON on the command-line, and there is now a [whole ecosystem of tools](https://ilya-sher.org/2018/04/10/list-of-json-tools-for-command-line/) that output and manipulate JSON.
>
> It is also widely used on the web, so by using JSON as the input and output of programs, you can pipe directly to and from web services using curl.
>
> (copied from [clig.dev](https://clig.dev/#output))