### PR TITLE
chore: Move `.pdm.toml` to `pdm.toml` + `.pdm-python`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.pdm.toml
+.pdm-python
 .directory
 .ide
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
pdm v2.5.0b0 has this breaking change.

> Move the project python path to its own file, and rename the project config file as pdm.toml which can be committed to the VCS.

https://pdm.fming.dev/latest/dev/changelog/#release-v250b0-2023-03-29

(`.gitignore` was automatically changed by `pdm fix project-config`.)