### PR TITLE
chore: Update ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ build-backend = "setuptools.build_meta"
 
 [tool.ruff]
 line-length = 88
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "N", "B", "SIM"]
 
 [tool.ruff.format]


### PR DESCRIPTION
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'select' -> 'lint.select'

https://github.com/astral-sh/ruff/releases/tag/v0.2.0
https://astral.sh/blog/ruff-v0.2.0#configuration-changes